### PR TITLE
renamed function AssertPrefixedIdentifierFromURI

### DIFF
--- a/context.go
+++ b/context.go
@@ -32,6 +32,9 @@ func (aContext *NamespaceContext) AssertPrefixedIdentifierFromURI(URI string) (s
 	if lastHash > 0 {
 		postfix := URI[lastHash+1:]
 		expansion := URI[:lastHash+1]
+		if postfix == "" {
+			return "", errors.New("unable to assert prefixed identifier from URI: " + URI + " - no postfix")
+		}
 
 		// check if expansion exists
 		if prefix, found := aContext.expansionToPrefixMappings[expansion]; found {
@@ -49,6 +52,9 @@ func (aContext *NamespaceContext) AssertPrefixedIdentifierFromURI(URI string) (s
 		if lastSlash > 0 {
 			postfix := URI[lastSlash+1:]
 			expansion := URI[:lastSlash+1]
+			if postfix == "" {
+				return "", errors.New("unable to assert prefixed identifier from URI: " + URI + " - no postfix")
+			}
 
 			// check if expansion exists
 			if prefix, found := aContext.expansionToPrefixMappings[expansion]; found {

--- a/context.go
+++ b/context.go
@@ -26,7 +26,7 @@ func (aContext *NamespaceContext) AsContext() *Context {
 	return context
 }
 
-func (aContext *NamespaceContext) AssertPrefixFromURI(URI string) (string, error) {
+func (aContext *NamespaceContext) AssertPrefixedIdentifierFromURI(URI string) (string, error) {
 	// find last hash or slash
 	lastHash := strings.LastIndex(URI, "#")
 	if lastHash > 0 {

--- a/entity_test.go
+++ b/entity_test.go
@@ -46,19 +46,26 @@ func TestCreateEntity(t *testing.T) {
 	}
 }
 
+func TestAssertIdentifierReturnsErrorWhenMissingPostfix(t *testing.T) {
+	// namespace manager
+	nsManager := NewNamespaceContext()
+	_, err := nsManager.AssertPrefixedIdentifierFromURI("http://data.example.com/things/")
+	if err == nil {
+		t.Error(err)
+	}
+}
+
 func TestCreateEntityUsingContextManager(t *testing.T) {
 	// namespace manager
 	nsManager := NewNamespaceContext()
-	ns1, err := nsManager.AssertPrefixedIdentifierFromURI("http://data.example.com/things/")
+	entityId, err := nsManager.AssertPrefixedIdentifierFromURI("http://data.example.com/things/entity1")
 	if err != nil {
 		t.Error(err)
 	}
 
-	// create a new entity
-	entityId := ns1 + ":entity1"
 	entity := NewEntity().SetID(entityId)
-	if entity.ID != entityId {
-		t.Errorf("expected entity id to be '%s:entity1', got '%s'", ns1, entity.ID)
+	if entity.ID != "ns0:entity1" {
+		t.Errorf("expected entity id to be 'ns0:entity1', got '%s'", entity.ID)
 	}
 
 	// add a property

--- a/entity_test.go
+++ b/entity_test.go
@@ -49,7 +49,7 @@ func TestCreateEntity(t *testing.T) {
 func TestCreateEntityUsingContextManager(t *testing.T) {
 	// namespace manager
 	nsManager := NewNamespaceContext()
-	ns1, err := nsManager.AssertPrefixFromURI("http://data.example.com/things/")
+	ns1, err := nsManager.AssertPrefixedIdentifierFromURI("http://data.example.com/things/")
 	if err != nil {
 		t.Error(err)
 	}

--- a/namespace.go
+++ b/namespace.go
@@ -8,6 +8,6 @@ type NamespaceManager interface {
 	GetFullURI(value string) (string, error)
 	GetPrefixedIdentifier(value string) (string, error)
 	GetNamespaceMappings() map[string]string
-	AssertPrefixFromURI(URI string) (string, error)
+	AssertPrefixedIdentifierFromURI(URI string) (string, error)
 	AsContext() *Context
 }

--- a/parser.go
+++ b/parser.go
@@ -74,7 +74,7 @@ func (esp *EntityParser) GetIdentityValue(value string) (string, error) {
 	var err error
 
 	if esp.compressURIs {
-		identity, err = esp.nsManager.AssertPrefixFromURI(value)
+		identity, err = esp.nsManager.AssertPrefixedIdentifierFromURI(value)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
No semantic change under the hood, but renamed it to be more precise and explanatory as this is a key function when programmatically creating entities.