### PR TITLE
allow compressed uris with extra colons

### DIFF
--- a/context.go
+++ b/context.go
@@ -102,10 +102,10 @@ func (aContext *NamespaceContext) isCURIE(value string) (bool, string, string) {
 		return false, "", ""
 	} else {
 		parts := strings.Split(value, ":")
-		if len(parts) != 2 {
+		if len(parts) < 2 {
 			return false, "", ""
 		}
-		return true, parts[0], parts[1]
+		return true, parts[0], value[len(parts[0])+1:]
 	}
 }
 


### PR DESCRIPTION
a compressed URI like `ns1:2023-12-13_13:00:00` should be allowed, because the unexpanded equivalent `http://example.com/2023-12-13_13:00` is valid.