### PR TITLE
improved handling of identity, better handling for nil props and refs

### DIFF
--- a/context.go
+++ b/context.go
@@ -150,3 +150,8 @@ func (aContext *NamespaceContext) GetPrefixedIdentifier(value string) (string, e
 		return value, nil
 	}
 }
+
+func (aContext *NamespaceContext) DoesExpansionExistForPrefix(prefix string) bool {
+	_, found := aContext.prefixToExpansionMappings[prefix]
+	return found
+}

--- a/namespace.go
+++ b/namespace.go
@@ -10,4 +10,5 @@ type NamespaceManager interface {
 	GetNamespaceMappings() map[string]string
 	AssertPrefixedIdentifierFromURI(URI string) (string, error)
 	AsContext() *Context
+	DoesExpansionExistForPrefix(prefix string) bool
 }

--- a/parser.go
+++ b/parser.go
@@ -97,8 +97,18 @@ func (esp *EntityParser) GetIdentityValue(value string) (string, error) {
 	}
 
 	// check that there is a valid expansion
-	if !esp.nsManager.DoesExpansionExistForPrefix(identity) {
-		return "", fmt.Errorf("no expansion for prefix: %s", identity)
+	var prefix string
+	if strings.Contains(identity, ":") {
+		// split the prefix and the local name
+		parts := strings.Split(identity, ":")
+		prefix = parts[0]
+	} else {
+		// check for the default prefix
+		prefix = "_"
+	}
+
+	if !esp.nsManager.DoesExpansionExistForPrefix(prefix) {
+		return "", fmt.Errorf("no expansion for prefix: %s", prefix)
 	}
 
 	return identity, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -1263,6 +1263,56 @@ func TestParserDetectsMissingNamespace(t *testing.T) {
 	}
 }
 
+func TestParserDetectsNamespace(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{ "ns0" : "http://data.sample.org/"}},
+		  {"id":"ns0:1","refs":{},"props":{"http://data.sample.org/Name":"John"}},
+		  {"id":"@continuation","token":"1725182073988287"}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	_, err := parser.LoadEntityCollection(byteReader)
+
+	if err != nil {
+		t.Error("Error validating namespace expansion")
+	}
+}
+
+func TestParserValidatesDefaultNamespace(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{ "_" : "http://data.sample.org/"}},
+		  {"id":"1","refs":{},"props":{"http://data.sample.org/Name":"John"}},
+		  {"id":"@continuation","token":"1725182073988287"}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	_, err := parser.LoadEntityCollection(byteReader)
+
+	if err != nil {
+		t.Error("Error validating namespace expansion")
+	}
+}
+
+func TestParserFailsWhenNoDefaultNamespace(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{ "ns0" : "http://data.sample.org/"}},
+		  {"id":"1","refs":{},"props":{"http://data.sample.org/Name":"John"}}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	_, err := parser.LoadEntityCollection(byteReader)
+
+	if err == nil {
+		t.Error("Error validating namespace expansion")
+	}
+}
+
 func TestParserDealsWithNullRefsAndProps(t *testing.T) {
 
 	byteReader := bytes.NewReader([]byte(`

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,7 +24,40 @@ func TestParseValidSimpleEntity(t *testing.T) {
 		]`))
 
 	nsManager := NewNamespaceContext()
-	parser := NewEntityParser(nsManager).WithExpandURIs()
+	parser := NewEntityParser(nsManager) //.WithExpandURIs()
+	entityCollection, err := parser.LoadEntityCollection(byteReader)
+
+	if err != nil {
+		t.Errorf("Error parsing entity collection: %s", err)
+	}
+	if len(entityCollection.Entities) != 1 {
+		t.Errorf("Expected 1 entity, got %d", len(entityCollection.Entities))
+	}
+	if entityCollection.Entities[0].ID != "http://example.com/1" {
+		t.Errorf("Expected entity id to be http://example.com/1, got %s", entityCollection.Entities[0].ID)
+	}
+	if len(entityCollection.Entities[0].Properties) != 1 {
+		t.Errorf("Expected entity properties to have 1 property, got %d", len(entityCollection.Entities[0].Properties))
+	}
+	if entityCollection.Entities[0].Properties["http://example.com/name"] != "John Smith" {
+		t.Errorf("Expected entity property name to be John Smith, got %s", entityCollection.Entities[0].Properties["name"])
+	}
+}
+
+func TestParseValidSimpleEntityNoContext(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[
+			{
+				"id": "http://example.com/1",
+				"props": {
+					"http://example.com/name": "John Smith"
+				}
+			}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager).WithNoContext().WithExpandURIs()
 	entityCollection, err := parser.LoadEntityCollection(byteReader)
 
 	if err != nil {
@@ -1186,4 +1219,63 @@ func TestParseCompressURIs(t *testing.T) {
 		t.Errorf("Expected context namespace ns1 to be http://www.w3.org/1999/02/22-rdf-syntax-ns#, got %s", context.Namespaces["ns1"])
 	}
 
+}
+
+func TestParseNoSpecialInstruction(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[
+{"id":"@context","namespaces":{}},
+{"id":"http://data.sample.org/things/1","refs":{},"props":{"http://data.sample.org/Name":"John"}},
+{"id":"http://data.sample.org/things/2","refs":{},"props":{"http://data.sample.org/Name":"Jane"}},
+{"id":"http://data.sample.org/things/3","refs":{},"props":{"http://data.sample.org/Name":"Jim"}},
+{"id":"@continuation","token":"1725182073988287"}]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	entityCollection, err := parser.LoadEntityCollection(byteReader)
+
+	if err != nil {
+		t.Errorf("Error parsing entity collection: %s", err)
+	}
+	if len(entityCollection.Entities) != 3 {
+		t.Errorf("Expected 1 entity, got %d", len(entityCollection.Entities))
+	}
+	if entityCollection.Entities[0].ID != "http://data.sample.org/things/1" {
+		t.Errorf("Expected entity id to be ns0:1, got %s", entityCollection.Entities[0].ID)
+	}
+}
+
+func TestParserDetectsMissingNamespace(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"ns0:1","refs":{},"props":{"http://data.sample.org/Name":"John"}},
+		  {"id":"@continuation","token":"1725182073988287"}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	_, err := parser.LoadEntityCollection(byteReader)
+
+	if err == nil {
+		t.Error("Failed to detect missing namespace expansion")
+	}
+}
+
+func TestParserDealsWithNullRefsAndProps(t *testing.T) {
+
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"http://data.sample.org/1","refs":null,"props":{"http://data.sample.org/Name":"John"}},
+		  {"id":"http://data.sample.org/2","refs":{},"props":null}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	_, err := parser.LoadEntityCollection(byteReader)
+
+	if err != nil {
+		t.Errorf("Failed to parse collection with null refs %s", err)
+	}
 }


### PR DESCRIPTION
Identity: the parser now validates but also properly tolerates full URIs even when expandURIs is not set.
Refs and Props: null values for these are now tolerated, and no error occurs.