### PR TITLE
Fix sub entity ns expansion

### DIFF
--- a/entity_test.go
+++ b/entity_test.go
@@ -95,6 +95,37 @@ func TestExpandPrefixesWithMissingExpansion(t *testing.T) {
 	}
 }
 
+func TestExpandPrefixesWithValueArray(t *testing.T) {
+	// namespace manager
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	// create entity using short form
+	entity := NewEntity().SetID("ns0:entity1")
+
+	// add some properties and references
+	propArray := []any{"value1"}
+	entity.SetProperty("ns0:property1", propArray)
+
+	// create entity collection and add entity
+	ec := NewEntityCollection(nsManager)
+	err := ec.AddEntity(entity)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// expand prefixes
+	err = ec.ExpandNamespacePrefixes()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check that the property has been expanded
+	if entity.Properties["http://data.example.com/things/property1"].([]any)[0] != propArray[0] {
+		t.Errorf("expected entity property to be array, got '%s'", entity.Properties["http://data.example.com/things/property1"])
+	}
+
+}
+
 func TestExpandPrefixesWithSubEntity(t *testing.T) {
 	// namespace manager
 	nsManager := NewNamespaceContext()

--- a/entity_test.go
+++ b/entity_test.go
@@ -134,6 +134,44 @@ func TestExpandPrefixesWithSubEntity(t *testing.T) {
 	entity := NewEntity().SetID("ns0:entity1")
 
 	// add some properties and references
+	subEntity := NewEntity().SetID("ns0:entity2")
+	subEntity.Properties["ns0:subproperty1"] = "value2"
+
+	entity.SetProperty("ns0:subEntity", subEntity)
+
+	// create entity collection and add entity
+	ec := NewEntityCollection(nsManager)
+	err := ec.AddEntity(entity)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// expand prefixes
+	err = ec.ExpandNamespacePrefixes()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check that the property has been expanded
+	val, exist := entity.Properties["http://data.example.com/things/subEntity"]
+	if exist {
+		sub := val.(*Entity)
+		if sub.Properties["http://data.example.com/things/subproperty1"] != "value2" {
+			t.Errorf("expected sub entity property to be 'value2', got '%s'", sub.Properties["http://data.example.com/things/subproperty1"])
+		}
+	} else {
+		t.Error("expected resolved sub entity property to exist")
+	}
+}
+
+func TestExpandPrefixesWithSubEntityArray(t *testing.T) {
+	// namespace manager
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	// create entity using short form
+	entity := NewEntity().SetID("ns0:entity1")
+
+	// add some properties and references
 	var subEntities []*Entity
 	subEntity := NewEntity().SetID("ns0:entity2")
 	subEntity.Properties["ns0:subproperty1"] = "value2"
@@ -167,6 +205,43 @@ func TestExpandPrefixesWithSubEntity(t *testing.T) {
 }
 
 func TestExpandPrefixesWithSubEntityAsMap(t *testing.T) {
+	// namespace manager
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	// create entity using short form
+	entity := NewEntity().SetID("ns0:entity1")
+
+	// add some properties and references
+	subEntity := map[string]any{"id": "ns0:entity2", "props": map[string]any{"ns0:subproperty1": "value2"}}
+
+	entity.SetProperty("ns0:subEntity", subEntity)
+
+	// create entity collection and add entity
+	ec := NewEntityCollection(nsManager)
+	err := ec.AddEntity(entity)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// expand prefixes
+	err = ec.ExpandNamespacePrefixes()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check that the property has been expanded
+	val, exist := entity.Properties["http://data.example.com/things/subEntity"]
+	if exist {
+		sub := val.(*Entity)
+		if sub.Properties["http://data.example.com/things/subproperty1"] != "value2" {
+			t.Errorf("expected sub entity property to be 'value2', got '%s'", sub.Properties["http://data.example.com/things/subproperty1"])
+		}
+	} else {
+		t.Error("expected resolved sub entity property to exist")
+	}
+}
+
+func TestExpandPrefixesWithSubEntityAsMapArray(t *testing.T) {
 	// namespace manager
 	nsManager := NewNamespaceContext()
 	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")

--- a/entitycollection.go
+++ b/entitycollection.go
@@ -249,19 +249,27 @@ func (ec *EntityCollection) expandEntityNamespaces(entity *Entity) error {
 			}
 			entity.Properties[fullType] = newEc.GetEntities()
 		case []interface{}:
-			// assuming sub entities
-			newEc := NewEntityCollection(ec.NamespaceManager)
-			for _, subEntity := range propertyValue.([]interface{}) {
-				err = newEc.AddEntityFromMap(subEntity.(map[string]any))
+			switch propertyValue.([]interface{})[0].(type) {
+			case map[string]any:
+				// assuming sub entities
+				newEc := NewEntityCollection(ec.NamespaceManager)
+				for _, subEntity := range propertyValue.([]interface{}) {
+					switch subEntity.(type) {
+					case map[string]any:
+					}
+					err = newEc.AddEntityFromMap(subEntity.(map[string]any))
+					if err != nil {
+						return err
+					}
+				}
+				err = newEc.ExpandNamespacePrefixes()
 				if err != nil {
 					return err
 				}
+				entity.Properties[fullType] = newEc.GetEntities()
+			default:
+				entity.Properties[fullType] = propertyValue
 			}
-			err = newEc.ExpandNamespacePrefixes()
-			if err != nil {
-				return err
-			}
-			entity.Properties[fullType] = newEc.GetEntities()
 		default:
 			entity.Properties[fullType] = propertyValue
 		}


### PR DESCRIPTION
Currently `ExpandNamespacePrefixes()` on EntityCollections only works on the main entity properties. If an entity has sub entities, they will keep the namespace prefix. This change will fix that.