### PR TITLE
fix: bad property getter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	go test ./... -v

--- a/entity.go
+++ b/entity.go
@@ -72,6 +72,14 @@ func (anEntity *Entity) GetFirstStringPropertyValue(typeURI string) (string, err
 func (anEntity *Entity) GetStringPropertyValues(typeURI string) ([]string, error) {
 	if values, found := anEntity.Properties[typeURI]; found {
 		switch v := values.(type) {
+		case []any:
+			result := make([]string, 0, len(v))
+			for _, val := range v {
+				if strVal, ok := val.(string); ok {
+					result = append(result, strVal)
+				}
+			}
+			return result, nil
 		case []string:
 			return v, nil
 		case string:

--- a/entity_test.go
+++ b/entity_test.go
@@ -64,6 +64,143 @@ func TestExpandPrefixes(t *testing.T) {
 	}
 }
 
+// expandEntityNamespaces: []any of scalar values (e.g. string URIs from JSON unmarshal)
+func TestExpandPrefixesWithAnySliceOfScalars(t *testing.T) {
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	entity := NewEntity().SetID("ns0:entity1")
+	entity.SetProperty("ns0:tags", []any{"value1", "value2", "value3"})
+
+	ec := NewEntityCollection(nsManager)
+	if err := ec.AddEntity(entity); err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.ExpandNamespacePrefixes(); err != nil {
+		t.Fatal(err)
+	}
+
+	vals, ok := entity.Properties["http://data.example.com/things/tags"].([]any)
+	if !ok || len(vals) != 3 {
+		t.Fatalf("expected []any with 3 elements, got %T %v", entity.Properties["http://data.example.com/things/tags"], entity.Properties["http://data.example.com/things/tags"])
+	}
+	if vals[0] != "value1" || vals[1] != "value2" || vals[2] != "value3" {
+		t.Errorf("unexpected values: %v", vals)
+	}
+}
+
+// expandEntityNamespaces: []any of map[string]any (sub-entities from JSON unmarshal)
+func TestExpandPrefixesWithAnySliceOfSubEntityMaps(t *testing.T) {
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	entity := NewEntity().SetID("ns0:entity1")
+
+	subEntities := []any{
+		map[string]any{"id": "ns0:sub1", "props": map[string]any{"ns0:subprop": "val1"}},
+		map[string]any{"id": "ns0:sub2", "props": map[string]any{"ns0:subprop": "val2"}},
+	}
+	entity.SetProperty("ns0:children", subEntities)
+
+	ec := NewEntityCollection(nsManager)
+	if err := ec.AddEntity(entity); err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.ExpandNamespacePrefixes(); err != nil {
+		t.Fatal(err)
+	}
+
+	expanded, ok := entity.Properties["http://data.example.com/things/children"].([]*Entity)
+	if !ok || len(expanded) != 2 {
+		t.Fatalf("expected []*Entity with 2 elements, got %T", entity.Properties["http://data.example.com/things/children"])
+	}
+	if expanded[0].ID != "http://data.example.com/things/sub1" {
+		t.Errorf("expected sub1 id to be expanded, got %s", expanded[0].ID)
+	}
+	if expanded[1].Properties["http://data.example.com/things/subprop"] != "val2" {
+		t.Errorf("expected sub2 subprop to be expanded, got %v", expanded[1].Properties)
+	}
+}
+
+// expandEntityNamespaces: map[string]any sub-entity (single, from JSON unmarshal)
+func TestExpandPrefixesWithMapSubEntity(t *testing.T) {
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	entity := NewEntity().SetID("ns0:entity1")
+	entity.SetProperty("ns0:child", map[string]any{
+		"id":    "ns0:sub1",
+		"props": map[string]any{"ns0:subprop": "val1"},
+	})
+
+	ec := NewEntityCollection(nsManager)
+	if err := ec.AddEntity(entity); err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.ExpandNamespacePrefixes(); err != nil {
+		t.Fatal(err)
+	}
+
+	sub, ok := entity.Properties["http://data.example.com/things/child"].(*Entity)
+	if !ok {
+		t.Fatalf("expected *Entity, got %T", entity.Properties["http://data.example.com/things/child"])
+	}
+	if sub.ID != "http://data.example.com/things/sub1" {
+		t.Errorf("expected sub id to be expanded, got %s", sub.ID)
+	}
+	if sub.Properties["http://data.example.com/things/subprop"] != "val1" {
+		t.Errorf("expected subprop to be expanded, got %v", sub.Properties)
+	}
+}
+
+// expandRefValues: []interface{} refs (from JSON unmarshal)
+func TestExpandPrefixesWithInterfaceSliceRefs(t *testing.T) {
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	entity := NewEntity().SetID("ns0:entity1")
+	entity.SetReference("ns0:links", []interface{}{"ns0:entity2", "ns0:entity3"})
+
+	ec := NewEntityCollection(nsManager)
+	if err := ec.AddEntity(entity); err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.ExpandNamespacePrefixes(); err != nil {
+		t.Fatal(err)
+	}
+
+	refs, ok := entity.References["http://data.example.com/things/links"].([]interface{})
+	if !ok || len(refs) != 2 {
+		t.Fatalf("expected []interface{} with 2 elements, got %T", entity.References["http://data.example.com/things/links"])
+	}
+	if refs[0] != "http://data.example.com/things/entity2" {
+		t.Errorf("expected entity2 ref to be expanded, got %s", refs[0])
+	}
+	if refs[1] != "http://data.example.com/things/entity3" {
+		t.Errorf("expected entity3 ref to be expanded, got %s", refs[1])
+	}
+}
+
+// expandEntityNamespaces: scalar default (non-string, non-entity property value)
+func TestExpandPrefixesWithScalarProperty(t *testing.T) {
+	nsManager := NewNamespaceContext()
+	nsManager.StorePrefixExpansionMapping("ns0", "http://data.example.com/things/")
+	entity := NewEntity().SetID("ns0:entity1")
+	entity.SetProperty("ns0:count", 42)
+	entity.SetProperty("ns0:flag", false)
+
+	ec := NewEntityCollection(nsManager)
+	if err := ec.AddEntity(entity); err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.ExpandNamespacePrefixes(); err != nil {
+		t.Fatal(err)
+	}
+
+	if entity.Properties["http://data.example.com/things/count"] != 42 {
+		t.Errorf("expected count=42, got %v", entity.Properties["http://data.example.com/things/count"])
+	}
+	if entity.Properties["http://data.example.com/things/flag"] != false {
+		t.Errorf("expected flag=false, got %v", entity.Properties["http://data.example.com/things/flag"])
+	}
+}
+
 func TestExpandPrefixesWithMissingExpansion(t *testing.T) {
 	// namespace manager
 	nsManager := NewNamespaceContext()
@@ -277,6 +414,102 @@ func TestExpandPrefixesWithSubEntityAsMapArray(t *testing.T) {
 		}
 	} else {
 		t.Error("expected resolved sub entity property to exist")
+	}
+}
+
+func TestGetStringPropertyValuesFromParsedJSON(t *testing.T) {
+	// This is the real-world case that exposed the bug: JSON arrays unmarshal as []interface{},
+	// not []string, so GetStringPropertyValues must handle []any.
+	data := map[string]any{
+		"id":      "http://data.mimiro.io/e360/organizations/018eccea-0040-78ae-b066-e8bd8dfd9b2d",
+		"deleted": false,
+		"refs": map[string]any{
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns/type": "http://data.mimiro.io/e360/Organization",
+		},
+		"props": map[string]any{
+			"http://data.mimiro.io/e360/props.name": "Test Johan",
+			"http://data.mimiro.io/e360/props.externalIdentifiers.val": []any{
+				"http://data.mimiro.io/prodreg/producer-code/3425011396",
+				"http://data.mimiro.io/prodreg/farm-code/34250113",
+				"http://data.mimiro.io/prodreg/herdidentifier/2504433",
+				"http://data.mimiro.io/prodreg/pid/10003427241",
+				"http://data.mimiro.io/bronnoysund/organization-number/992666862",
+			},
+		},
+	}
+
+	ec := NewEntityCollection(nil)
+	if err := ec.AddEntityFromMap(data); err != nil {
+		t.Fatalf("unexpected error adding entity from map: %s", err)
+	}
+
+	entity := ec.Entities[0]
+	values, err := entity.GetStringPropertyValues("http://data.mimiro.io/e360/props.externalIdentifiers.val")
+	if err != nil {
+		t.Fatalf("GetStringPropertyValues returned error: %s", err)
+	}
+
+	expected := []string{
+		"http://data.mimiro.io/prodreg/producer-code/3425011396",
+		"http://data.mimiro.io/prodreg/farm-code/34250113",
+		"http://data.mimiro.io/prodreg/herdidentifier/2504433",
+		"http://data.mimiro.io/prodreg/pid/10003427241",
+		"http://data.mimiro.io/bronnoysund/organization-number/992666862",
+	}
+	if len(values) != len(expected) {
+		t.Fatalf("expected %d values, got %d: %v", len(expected), len(values), values)
+	}
+	for i, v := range values {
+		if v != expected[i] {
+			t.Errorf("values[%d]: expected %q, got %q", i, expected[i], v)
+		}
+	}
+}
+
+func TestGetStringPropertyValues(t *testing.T) {
+	entity := NewEntity().SetID("ns0:entity1")
+
+	// []string case
+	entity.SetProperty("ns0:strSlice", []string{"a", "b", "c"})
+	if values, err := entity.GetStringPropertyValues("ns0:strSlice"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(values) != 3 || values[0] != "a" || values[1] != "b" || values[2] != "c" {
+		t.Errorf("unexpected values: %v", values)
+	}
+
+	// []any with all strings
+	entity.SetProperty("ns0:anySlice", []any{"x", "y"})
+	if values, err := entity.GetStringPropertyValues("ns0:anySlice"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(values) != 2 || values[0] != "x" || values[1] != "y" {
+		t.Errorf("unexpected values: %v", values)
+	}
+
+	// []any with non-string elements should skip them, not insert ""
+	entity.SetProperty("ns0:mixedSlice", []any{"hello", 42, "world"})
+	if values, err := entity.GetStringPropertyValues("ns0:mixedSlice"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(values) != 2 || values[0] != "hello" || values[1] != "world" {
+		t.Errorf("expected non-string elements to be skipped, got: %v", values)
+	}
+
+	// single string case
+	entity.SetProperty("ns0:singleStr", "solo")
+	if values, err := entity.GetStringPropertyValues("ns0:singleStr"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(values) != 1 || values[0] != "solo" {
+		t.Errorf("unexpected values: %v", values)
+	}
+
+	// missing key
+	if _, err := entity.GetStringPropertyValues("ns0:missing"); err == nil {
+		t.Error("expected error for missing key")
+	}
+
+	// wrong type
+	entity.SetProperty("ns0:badType", 123)
+	if _, err := entity.GetStringPropertyValues("ns0:badType"); err == nil {
+		t.Error("expected error for non-string property type")
 	}
 }
 

--- a/entitycollection.go
+++ b/entitycollection.go
@@ -236,10 +236,10 @@ func (ec *EntityCollection) expandEntityNamespaces(entity *Entity) error {
 		// remove old key
 		delete(entity.Properties, typeURI)
 
-		switch propertyValue.(type) {
+		switch v := propertyValue.(type) {
 		case []*Entity:
 			newEc := NewEntityCollection(ec.NamespaceManager)
-			for _, subEntity := range propertyValue.([]*Entity) {
+			for _, subEntity := range v {
 				err = newEc.AddEntity(subEntity)
 				if err != nil {
 					return err
@@ -250,15 +250,12 @@ func (ec *EntityCollection) expandEntityNamespaces(entity *Entity) error {
 				return err
 			}
 			entity.Properties[fullType] = newEc.GetEntities()
-		case []interface{}:
-			switch propertyValue.([]interface{})[0].(type) {
+		case []any:
+			switch v[0].(type) {
 			case map[string]any:
 				// assuming sub entities
 				newEc := NewEntityCollection(ec.NamespaceManager)
-				for _, subEntity := range propertyValue.([]interface{}) {
-					switch subEntity.(type) {
-					case map[string]any:
-					}
+				for _, subEntity := range v {
 					err = newEc.AddEntityFromMap(subEntity.(map[string]any))
 					if err != nil {
 						return err
@@ -270,12 +267,12 @@ func (ec *EntityCollection) expandEntityNamespaces(entity *Entity) error {
 				}
 				entity.Properties[fullType] = newEc.GetEntities()
 			default:
-				entity.Properties[fullType] = propertyValue
+				entity.Properties[fullType] = v
 			}
 		case map[string]any:
 			// assuming sub entity
 			newEc := NewEntityCollection(ec.NamespaceManager)
-			err = newEc.AddEntityFromMap(propertyValue.(map[string]any))
+			err = newEc.AddEntityFromMap(v)
 			if err != nil {
 				return err
 			}
@@ -286,7 +283,7 @@ func (ec *EntityCollection) expandEntityNamespaces(entity *Entity) error {
 			entity.Properties[fullType] = newEc.GetEntities()[0]
 		case *Entity:
 			newEc := NewEntityCollection(ec.NamespaceManager)
-			err = newEc.AddEntity(propertyValue.(*Entity))
+			err = newEc.AddEntity(v)
 			if err != nil {
 				return err
 			}
@@ -327,34 +324,34 @@ func (ec *EntityCollection) expandEntityNamespaces(entity *Entity) error {
 
 func (ec *EntityCollection) expandRefValues(values any) (any, error) {
 	// switch if string or []string
-	switch values.(type) {
+	switch v := values.(type) {
 	case string:
 		// expand ref value
-		fullRefValue, err := ec.NamespaceManager.GetFullURI(values.(string))
+		fullRefValue, err := ec.NamespaceManager.GetFullURI(v)
 		if err != nil {
 			return nil, err
 		}
 		return fullRefValue, nil
 	case []interface{}:
 		// expand ref values
-		for i, refValue := range values.([]interface{}) {
+		for i, refValue := range v {
 			fullRefValue, err := ec.NamespaceManager.GetFullURI(refValue.(string))
 			if err != nil {
 				return nil, err
 			}
-			values.([]interface{})[i] = fullRefValue
+			v[i] = fullRefValue
 		}
-		return values, nil
+		return v, nil
 	case []string:
 		// expand ref values
-		for i, refValue := range values.([]string) {
+		for i, refValue := range v {
 			fullRefValue, err := ec.NamespaceManager.GetFullURI(refValue)
 			if err != nil {
 				return nil, err
 			}
-			values.([]string)[i] = fullRefValue
+			v[i] = fullRefValue
 		}
-		return values, nil
+		return v, nil
 	}
 
 	return nil, errors.New("unexpected type in refs")

--- a/parser.go
+++ b/parser.go
@@ -216,48 +216,49 @@ func (esp *EntityParser) parseEntity(decoder *json.Decoder) (*Entity, error) {
 				return e, nil
 			}
 		case string:
-			if v == "id" {
+			switch v {
+			case "id":
 				val, err := decoder.Token()
 				if err != nil {
 					return nil, fmt.Errorf("unable to read token of id value: %w", err)
 				}
 
-				if val.(string) == "@continuation" {
+				switch val.(string) {
+				case "@continuation":
 					e.ID = "@continuation"
 					isContinuation = true
-				} else if val.(string) == "@context" {
+				case "@context":
 					return nil, errors.New("context object found when entity expected")
-				} else {
+				default:
 					id, err := esp.GetIdentityValue(val.(string))
 					if err != nil {
 						return nil, err
 					}
 					e.ID = id
 				}
-			} else if v == "recorded" {
+			case "recorded":
 				val, err := decoder.Token()
 				if err != nil {
 					return nil, fmt.Errorf("unable to read token of recorded value: %w", err)
 				}
 				e.Recorded = uint64(val.(float64))
-			} else if v == "deleted" {
+			case "deleted":
 				val, err := decoder.Token()
 				if err != nil {
 					return nil, fmt.Errorf("unable to read token of deleted value: %w", err)
 				}
 				e.IsDeleted = val.(bool)
-
-			} else if v == "props" {
+			case "props":
 				e.Properties, err = esp.parseProperties(decoder)
 				if err != nil {
 					return nil, fmt.Errorf("unable to parse properties: %w", err)
 				}
-			} else if v == "refs" {
+			case "refs":
 				e.References, err = esp.parseReferences(decoder)
 				if err != nil {
 					return nil, fmt.Errorf("unable to parse references %w", err)
 				}
-			} else if v == "token" {
+			case "token":
 				if !isContinuation {
 					return nil, errors.New("token property found but not a continuation entity")
 				}
@@ -267,7 +268,7 @@ func (esp *EntityParser) parseEntity(decoder *json.Decoder) (*Entity, error) {
 				}
 				e.Properties = make(map[string]any)
 				e.Properties["token"] = val
-			} else {
+			default:
 				// log named property
 				// read value
 				_, err := decoder.Token()
@@ -432,15 +433,16 @@ func (esp *EntityParser) parseArray(decoder *json.Decoder) ([]any, error) {
 
 		switch v := t.(type) {
 		case json.Delim:
-			if v == '{' {
+			switch v {
+			case '{':
 				r, err := esp.parseEntity(decoder)
 				if err != nil {
 					return nil, fmt.Errorf("unable to parse array: %w", err)
 				}
 				array = append(array, r)
-			} else if v == ']' {
+			case ']':
 				return array, nil
-			} else if v == '[' {
+			case '[':
 				r, err := esp.parseArray(decoder)
 				if err != nil {
 					return nil, fmt.Errorf("unable to parse array: %w", err)
@@ -475,9 +477,10 @@ func (esp *EntityParser) parseValue(decoder *json.Decoder) (any, error) {
 
 		switch v := t.(type) {
 		case json.Delim:
-			if v == '{' {
+			switch v {
+			case '{':
 				return esp.parseEntity(decoder)
-			} else if v == '[' {
+			case '[':
 				return esp.parseArray(decoder)
 			}
 		case string:

--- a/parser_test.go
+++ b/parser_test.go
@@ -1027,7 +1027,9 @@ func TestToJSONLDWithEmbeddedEntityArray(t *testing.T) {
 
 	// write it out again
 	bytesBuffer := bytes.Buffer{}
-	entityCollection.WriteJSON_LD(&bytesBuffer)
+	if err := entityCollection.WriteJSON_LD(&bytesBuffer); err != nil {
+		t.Errorf("Error writing entity collection: %s", err)
+	}
 }
 
 func TestParseWithDefaultNamespaceExpansionInPropName(t *testing.T) {
@@ -1327,5 +1329,101 @@ func TestParserDealsWithNullRefsAndProps(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Failed to parse collection with null refs %s", err)
+	}
+}
+
+// parseEntity: "recorded" field is parsed into entity.Recorded
+func TestParseEntityWithRecorded(t *testing.T) {
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"http://data.example.com/1","recorded":1730979552787404544,"props":{}}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	ec, err := parser.LoadEntityCollection(byteReader)
+	if err != nil {
+		t.Fatalf("Error parsing entity collection: %s", err)
+	}
+	if ec.Entities[0].Recorded != 1730979552787404544 {
+		t.Errorf("expected Recorded=1730979552787404544, got %d", ec.Entities[0].Recorded)
+	}
+}
+
+// parseEntity: "deleted" field is parsed into entity.IsDeleted
+func TestParseEntityWithDeleted(t *testing.T) {
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"http://data.example.com/1","deleted":true,"props":{}}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	ec, err := parser.LoadEntityCollection(byteReader)
+	if err != nil {
+		t.Fatalf("Error parsing entity collection: %s", err)
+	}
+	if !ec.Entities[0].IsDeleted {
+		t.Error("expected IsDeleted=true")
+	}
+}
+
+// parseEntity: encountering "@context" as an entity id (not the first element) returns an error
+func TestParseContextObjectAsEntityReturnsError(t *testing.T) {
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"@context","namespaces":{}}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	_, err := parser.LoadEntityCollection(byteReader)
+	if err == nil {
+		t.Error("expected error when @context object appears where entity is expected")
+	}
+}
+
+// parseArray: nested array value (the '[' delimiter branch in parseArray)
+func TestParsePropertyWithNestedArray(t *testing.T) {
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"http://data.example.com/1","props":{"http://data.example.com/matrix":[[1,2],[3,4]]}}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	ec, err := parser.LoadEntityCollection(byteReader)
+	if err != nil {
+		t.Fatalf("Error parsing entity collection: %s", err)
+	}
+	matrix, ok := ec.Entities[0].Properties["http://data.example.com/matrix"].([]any)
+	if !ok || len(matrix) != 2 {
+		t.Fatalf("expected []any with 2 rows, got %T %v", ec.Entities[0].Properties["http://data.example.com/matrix"], ec.Entities[0].Properties["http://data.example.com/matrix"])
+	}
+	row0, ok := matrix[0].([]any)
+	if !ok || len(row0) != 2 {
+		t.Fatalf("expected row0 to be []any with 2 elements, got %T", matrix[0])
+	}
+}
+
+// parseValue: array as a property value (the '[' delimiter branch in parseValue)
+func TestParsePropertyWithArrayValue(t *testing.T) {
+	byteReader := bytes.NewReader([]byte(`
+		[ {"id":"@context","namespaces":{}},
+		  {"id":"http://data.example.com/1","props":{"http://data.example.com/tags":["a","b","c"]}}
+		]`))
+
+	nsManager := NewNamespaceContext()
+	parser := NewEntityParser(nsManager)
+	ec, err := parser.LoadEntityCollection(byteReader)
+	if err != nil {
+		t.Fatalf("Error parsing entity collection: %s", err)
+	}
+	tags, ok := ec.Entities[0].Properties["http://data.example.com/tags"].([]any)
+	if !ok || len(tags) != 3 {
+		t.Fatalf("expected []any with 3 elements, got %T %v", ec.Entities[0].Properties["http://data.example.com/tags"], ec.Entities[0].Properties["http://data.example.com/tags"])
+	}
+	if tags[0] != "a" || tags[1] != "b" || tags[2] != "c" {
+		t.Errorf("unexpected tag values: %v", tags)
 	}
 }


### PR DESCRIPTION
The GetStringPropertyValues method in the Entity struct was not handling the case where the property value is a slice of any type ([]any). This commit adds support for this case by iterating over the slice and extracting string values, if present. Additionally, the Makefile has been updated to run tests with verbose output.

Additionlly, linting was ran against the codebase and some minor formatting issues were fixed in the entitycollection.go file. Tests have been added to check the linter fixes.